### PR TITLE
Fix RawElectricityPriceResponse struct and color parsing

### DIFF
--- a/KwhApp/Util/HexColor.swift
+++ b/KwhApp/Util/HexColor.swift
@@ -16,7 +16,12 @@ extension Color {
         let a, r, g, b: UInt64
         switch hex.count {
         case 3:
-            (a, r, g, b) = (255, (int >> 8 * 17) & 0xFF, (int >> 4 * 17) & 0xFF, int * 17 & 0xFF)
+            (a, r, g, b) = (
+                255,
+                ((int >> 8) & 0xF) * 17,
+                ((int >> 4) & 0xF) * 17,
+                (int & 0xF) * 17
+            )
         case 6:
             (a, r, g, b) = (255, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
         case 8:

--- a/RawElectricityPriceResponse.swift
+++ b/RawElectricityPriceResponse.swift
@@ -8,17 +8,71 @@
 import Foundation
 
 struct RawElectricityPriceResponse: Codable {
-    let include: [Included]
+    let data: DataClass
+    let included: [Included]
+
+    struct DataClass: Codable {
+        let type: String
+        let id: String
+        let attributes: DataAttributes
+        let meta: Meta
+    }
+
+    struct DataAttributes: Codable {
+        let title: String
+        let lastUpdate: String
+        let description: String?
+
+        enum CodingKeys: String, CodingKey {
+            case title
+            case lastUpdate = "last-update"
+            case description
+        }
+    }
+
+    struct Meta: Codable {
+        let cacheControl: CacheControl
+
+        enum CodingKeys: String, CodingKey {
+            case cacheControl = "cache-control"
+        }
+    }
+
+    struct CacheControl: Codable {
+        let cache: String
+    }
+
     struct Included: Codable {
-        let attributes: Attributes
+        let type: String
+        let id: String
+        let attributes: IncludedAttributes
     }
-    struct Attributes: Codable {
+
+    struct IncludedAttributes: Codable {
+        let title: String
+        let description: String?
+        let color: String
+        let type: String?
+        let magnitude: String
+        let composite: Bool
+        let lastUpdate: String
         let values: [Value]
-        
+
+        enum CodingKeys: String, CodingKey {
+            case title
+            case description
+            case color
+            case type
+            case magnitude
+            case composite
+            case lastUpdate = "last-update"
+            case values
+        }
     }
+
     struct Value: Codable {
         let value: Double
+        let percentage: Int
         let datetime: String
-        
     }
 }


### PR DESCRIPTION
## Summary
- bring main RawElectricityPriceResponse model in sync with API
- fix hex color parsing of 3-digit notation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684164c99858832e8cf0a9f8f18c7dfd